### PR TITLE
Issue #17 - Add Router Replace Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ public func push(_ destination: Destination)
 /// Push a list of destinations onto the stack.
 /// - Parameter destinations: The destinations to push.
 public func push(_ destinations: [Destination])
+
+/// Replace the current destinations stack with the input stack.
+/// - Parameter destinations: The new destinations stack.
+public func replace(with destinations: [Destination])
 ```
 
 <br>

--- a/Sources/Routing/Protocols/Routable.swift
+++ b/Sources/Routing/Protocols/Routable.swift
@@ -17,6 +17,7 @@ public protocol Routable: ObservableObject {
     func popToRoot()
     func push(_ destination: Destination)
     func push(_ destinations: [Destination])
+    func replace(with destinations: [Destination])
 }
 
 extension Routable {
@@ -57,5 +58,11 @@ extension Routable {
         for destination in destinations {
             stack.append(destination)
         }
+    }
+
+    /// Replace the current destinations stack with the input stack.
+    /// - Parameter destinations: The new destinations stack.
+    public func replace(with destinations: [Destination]) {
+        stack = destinations
     }
 }

--- a/Tests/RoutingTests/RoutableTests.swift
+++ b/Tests/RoutingTests/RoutableTests.swift
@@ -82,12 +82,14 @@ final class RoutableTests: XCTestCase {
     }
 
     func testReplaceWithEmptyDestinations() {
+        router.push([.settings, .profile, .settings])
         router.replace(with: [])
-        XCTAssertEqual(router.stack.count, 0)
+        XCTAssert(router.stack.isEmpty)
         XCTAssertEqual(router.stack, [MockRouter.Route]())
     }
 
     func testReplaceWithDestinations() {
+        router.push([.settings, .settings])
         router.replace(with: [.settings, .profile, .settings])
         XCTAssertEqual(router.stack.count, 3)
         XCTAssertEqual(router.stack, [.settings, .profile, .settings])

--- a/Tests/RoutingTests/RoutableTests.swift
+++ b/Tests/RoutingTests/RoutableTests.swift
@@ -80,6 +80,18 @@ final class RoutableTests: XCTestCase {
         XCTAssertEqual(router.stack.count, 2)
         XCTAssertEqual(router.stack, [.settings, .profile])
     }
+
+    func testReplaceWithEmptyDestinations() {
+        router.replace(with: [])
+        XCTAssertEqual(router.stack.count, 0)
+        XCTAssertEqual(router.stack, [MockRouter.Route]())
+    }
+
+    func testReplaceWithDestinations() {
+        router.replace(with: [.settings, .profile, .settings])
+        XCTAssertEqual(router.stack.count, 3)
+        XCTAssertEqual(router.stack, [.settings, .profile, .settings])
+    }
 }
 
 fileprivate class MockRouter: Routable {


### PR DESCRIPTION
These changes add ```replace(with destinations: [Destination])``` to the Routable protocol, enabling complete replacement of the current stack with a new stack of destinations.

# What it Does
* Closes #17 
* Add ```replace(with destinations: [Destination])``` to Routable
* Adds documentation to the README
* Add two unit tests to RoutableTests

# How I Tested
* I set up a demo project and replace the stack with [.detail, .detail, .detail, .settings] on the Settings view.
* Wrote two extra unit tests and verified all pass.

# Screenshot
<img width="320" alt="Router Replace Function in Action" src="https://github.com/JamesSedlacek/Routing/assets/111900227/59fdbf5f-8de0-4706-96f2-9cb51b3dbbf1">