### PR TITLE
RoutingView.router: StateObject changed to ObservedObject

### DIFF
--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -10,4 +10,6 @@ public final class Router<Routes: Routable>: RoutableObject {
     public typealias Destination = Routes
 
     @Published public var stack: [Routes] = []
+    
+    public init() {}
 }

--- a/Sources/Routing/Views/RoutingView.swift
+++ b/Sources/Routing/Views/RoutingView.swift
@@ -7,10 +7,11 @@
 import SwiftUI
 
 public struct RoutingView<RootView: View, Routes: Routable>: View {
-    @StateObject private var router: Router<Routes> = .init()
+    @ObservedObject private var router: Router<Routes>
     private let rootView: (Router<Routes>) -> RootView
-
-    public init(_ routeType: Routes.Type, @ViewBuilder rootView: @escaping (Router<Routes>) -> RootView) {
+    
+    public init(_ router: Router<Routes>, @ViewBuilder rootView: @escaping (Router<Routes>) -> RootView) {
+        self.router = router
         self.rootView = rootView
     }
 


### PR DESCRIPTION
Hi!
I really enjoy your lightweight navigation solution.

I guess, it can be better approach to store Router<Routable> variable somewhere outside RoutingView:
```swift
struct ContentView: View {
    @StateObject var router = Router<ExampleRoute>()
    
    var body: some View {
        RoutingView(router) { router in
            Button("Go to Settings") {
                router.navigate(to: .settings)
            }
        }
    }
}

enum ExampleRoute: Routable {
    case settings
    case details
    
    var body: some View {
        switch self {
        case .settings:
            SettingsView()
        case .details:
            DetailsView()
        }
    }
}
```
This solution is more flexible. For example, in case of MVVM architecture, we can store our route in the screen's ViewModel and build our business logic here:
```swift
class ContentViewModel: ObservableObject {
    var router = Router<ExampleRoute>()
    
    func routeToSettings() {
        // some logic
        router.navigate(to: .settings)
    }
}

struct ContentView: View {
    @StateObject var vm = ContentViewModel()
    
    var body: some View {
        RoutingView(vm.router) { router in
            Button("Go to Settings") {
                vm.routeToSettings()
            }
        }
    }
}
```
Now, we also can declare ExampleRoute's `settings` case associated value as `SettingsViewModel` and pass our router further:
```swift
class ContentViewModel: ObservableObject {
    var router = Router<ExampleRoute>()
    
    func routeToSettings() {
        let vm = SettingsViewModel(router: router)
        router.navigate(to: .settings(vm))
    }
}
```