### PR TITLE
remove .body from navigationDestination

### DIFF
--- a/Sources/Routing/Views/RoutingView.swift
+++ b/Sources/Routing/Views/RoutingView.swift
@@ -57,7 +57,7 @@ public struct RoutingView<Root: View, Routes: Routable>: View {
         NavigationStack(path: $routes) {
             root()
                 .navigationDestination(for: Routes.self) { view in
-                    view.body
+                    view
                 }
         }
     }


### PR DESCRIPTION
no need to use view.body because Routable already is a View and using .body may affect @StateObject and cause unknown behavior